### PR TITLE
Removing requirement for .env file

### DIFF
--- a/App-Template/.env.sample
+++ b/App-Template/.env.sample
@@ -1,8 +1,0 @@
-# Configuration for Middleman environment
-
-# URLs
-URL=127.0.0.1:3000
-
-# Adhoc ENVs
-LANG=en_US.UTF-8
-EDITOR=vim

--- a/App-Template/docker-compose.yml
+++ b/App-Template/docker-compose.yml
@@ -4,14 +4,12 @@
 version: '2.4'
 
 x-app: &app
-  image: middleman:latest
+  image: middleman:0.1.0
   mem_limit: 512m
   build:
     context: .
     dockerfile: Dockerfile
     target: development
-  env_file:
-    - .env
   volumes:
     - .:/usr/src/app:cached
     - bundler:/usr/local/bundle:delegated


### PR DESCRIPTION
Requiring the .env for Middleman is kind of overkill, so ditching that.