### PR TITLE
Fix: No longer trying to copy .env.example during build

### DIFF
--- a/.github/workflows/update-template-repo.yml
+++ b/.github/workflows/update-template-repo.yml
@@ -57,7 +57,6 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/App
         rsync -a $GITHUB_WORKSPACE/Docker-Middleman-Generator/App-Template/ $GITHUB_WORKSPACE/App/
-        cp $GITHUB_WORKSPACE/App/.env.sample $GITHUB_WORKSPACE/App/.env
     - name: Pull docker image
       run: |
         cd $GITHUB_WORKSPACE/App


### PR DESCRIPTION
I saw we couldn't actually build as `.env.example` wasn't present any more. Sorting that :)